### PR TITLE
Switched to 2.4.8. OpenCV is resolving too 2.4.9, but pod install fails.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,4 +3,5 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 inhibit_all_warnings!
 
-pod 'OpenCV', '~> 2.4'
+#pod 'OpenCV', '~> 2.4'
+pod 'OpenCV', '2.4.8'


### PR DESCRIPTION
Pod install gave the error below.
## Switched to the latest version that would install - 2.4.8

Installing OpenCV (2.4.9.1)

[!] Error installing OpenCV
[!] /usr/bin/unzip /Volumes/REDACTED/issue-21-OpenCV-FaceRec/Pods/OpenCV/file.zip -d /Volumes/REDACTED/issue-21-OpenCV-FaceRec/Pods/OpenCV

Archive:  /Volumes/REDACTED/issue-21-OpenCV-FaceRec/Pods/OpenCV/file.zip
  End-of-central-directory signature not found.  Either this file is not

  a zipfile, or it constitutes one disk of a multi-part archive.  In the

  latter case the central directory and zipfile comment will be found on

  the last disk(s) of this archive.

unzip:  cannot find zipfile directory in one of /Volumes/REDACTED/issue-21-OpenCV-FaceRec/Pods/OpenCV/file.zip or

```
    /Volumes/REDACTED/issue-21-OpenCV-FaceRec/Pods/OpenCV/file.zip.zip, and cannot find /Volumes/REDACTED/issue-21-OpenCV-FaceRec/Pods/OpenCV/file.zip.ZIP, period.
```
